### PR TITLE
add cargo build to run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A Node.js server has the simple demo backend:
 ## How to run
 
 ```bash
+cargo build
 wasm-pack build --dev --target web
 cd server
 yarn


### PR DESCRIPTION
Perhaps obvious to veteran rustaceans but not to larvae - need to run `cargo build` before the other instructions